### PR TITLE
FE-28 - Connect Wallet refactoring and layout implementation

### DIFF
--- a/packages/dev-frontend/src/@types/window.ethereum.d.ts
+++ b/packages/dev-frontend/src/@types/window.ethereum.d.ts
@@ -1,4 +1,5 @@
 declare interface Window {
+  account?: string
   ethereum?: {
     isMetaMask?: boolean;
   };

--- a/packages/dev-frontend/src/App.tsx
+++ b/packages/dev-frontend/src/App.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { Web3ReactProvider } from "@web3-react/core";
-import { Flex, Spinner, Heading, ThemeProvider, Paragraph } from "theme-ui";
+import { Flex, Spinner, Heading, ThemeProvider} from "theme-ui";
 
 import { BatchedWebSocketAugmentedWeb3Provider } from "@liquity/providers";
-import { LiquityProvider } from "./hooks/LiquityContext";
-import { WalletConnector } from "./components/WalletConnector";
-import { TransactionProvider } from "./components/Transaction";
-import { Icon } from "./components/Icon";
+
 import { getConfig } from "./config";
 import theme from "./theme";
 
@@ -42,26 +39,6 @@ const EthersWeb3ReactProvider: React.FC = ({ children }) => {
   );
 };
 
-const UnsupportedMainnetFallback: React.FC = () => (
-  <Flex
-    sx={{
-      flexDirection: "column",
-      alignItems: "center",
-      justifyContent: "center",
-      height: "100vh",
-      textAlign: "center"
-    }}
-  >
-    <Heading sx={{ mb: 3 }}>
-      <Icon name="exclamation-triangle" /> This app is for testing purposes only.
-    </Heading>
-
-    <Paragraph sx={{ mb: 3 }}>
-      Please change your network to Ropsten.
-    </Paragraph>
-  </Flex>
-);
-
 const App = () => {
   const loader = (
     <Flex sx={{ alignItems: "center", justifyContent: "center", height: "100vh", width: "100vw" }}>
@@ -69,39 +46,10 @@ const App = () => {
       <Heading>Loading...</Heading>
     </Flex>
   );
-
-  const unsupportedNetworkFallback = (chainId: number) => (
-    <Flex
-      sx={{
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        height: "100vh",
-        textAlign: "center"
-      }}
-    >
-      <Heading sx={{ mb: 3 }}>
-        <Icon name="exclamation-triangle" /> Threshold USD is not yet deployed to{" "}
-        {chainId === 1 ? "mainnet" : "this network"}.
-      </Heading>
-      Please switch to Ropsten.
-    </Flex>
-  );
-
   return (
     <EthersWeb3ReactProvider>
       <ThemeProvider theme={theme}>
-        <WalletConnector loader={loader}>
-          <LiquityProvider
-            loader={loader}
-            unsupportedNetworkFallback={unsupportedNetworkFallback}
-            unsupportedMainnetFallback={<UnsupportedMainnetFallback />}
-          >
-            <TransactionProvider>
-              <LiquityFrontend loader={loader} />
-            </TransactionProvider>
-          </LiquityProvider>
-        </WalletConnector>
+        <LiquityFrontend loader={loader} />
       </ThemeProvider>
     </EthersWeb3ReactProvider>
   );

--- a/packages/dev-frontend/src/LiquityFrontend.tsx
+++ b/packages/dev-frontend/src/LiquityFrontend.tsx
@@ -1,17 +1,14 @@
 import React from "react";
 import { Flex, Container } from "theme-ui";
 import { HashRouter as Router, Switch, Route } from "react-router-dom";
-import { Wallet } from "@ethersproject/wallet";
 
-import { Decimal, Difference, Trove } from "@liquity/lib-base";
-import { LiquityStoreProvider } from "@liquity/lib-react";
-
-import { useLiquity } from "./hooks/LiquityContext";
-import { TransactionMonitor } from "./components/Transaction";
 import { Nav } from "./components/Nav";
 import { SideBar } from "./components/SideBar";
 import { HamburgerMenu } from "./components/HamburgerMenu";
 import { Header } from "./components/Header";
+import { WalletConnector } from "./components/WalletConnector";
+import { TransactionProvider } from "./components/Transaction";
+import { FunctionalPanel } from "./components/FunctionalPanel";
 
 import { PageSwitcher } from "./pages/PageSwitcher";
 import { RedemptionPage } from "./pages/RedemptionPage";
@@ -19,66 +16,101 @@ import { RiskyVaultsPage } from "./pages/RiskyVaultsPage";
 import { StabilityPoolPage } from "./pages/StabilityPoolPage";
 import { VaultPage } from "./pages/VaultPage";
 
-import { TroveViewProvider } from "./components/Trove/context/TroveViewProvider";
+import { LiquityProvider } from "./hooks/LiquityContext";
 
 type LiquityFrontendProps = {
   loader?: React.ReactNode;
 };
-export const LiquityFrontend: React.FC<LiquityFrontendProps> = ({ loader }) => {
-  const { account, provider, liquity } = useLiquity();
 
-  // For console tinkering ;-)
-  Object.assign(window, {
-    account,
-    provider,
-    liquity,
-    Trove,
-    Decimal,
-    Difference,
-    Wallet
-  });
+const UnsupportedMainnetFallback: React.FC = () => (
+  <Flex
+    sx={{
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      height: "100vh",
+      textAlign: "center"
+    }}
+  >
+    
+      This app is for testing purposes only.
+  
+
+
+      Please change your network to Ropsten.
+  
+  </Flex>
+);
+
+export const LiquityFrontend: React.FC<LiquityFrontendProps> = ({ loader }) => {
+  const unsupportedNetworkFallback = (chainId: number) => (
+    <Flex
+      sx={{
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "100vh",
+        textAlign: "center"
+      }}
+    >
+      
+        hreshold USD is not yet deployed to{" "}
+        {chainId === 1 ? "mainnet" : "this network"}.
+
+      Please switch to Ropsten.
+    </Flex>
+  );
 
   return (
-    <LiquityStoreProvider {...{ loader }} store={liquity.store}>
+    <>
       <Router>
-        <TroveViewProvider>
-            <Flex variant="layout.wrapper">
-              <Header>
-                <HamburgerMenu />
-              </Header>
-              <SideBar>
-                <Nav />
-              </SideBar>
-              <Container
-                variant="main"
-                sx={{
-                  flexGrow: 1,
-                  flexDirection: "column",
-                  alignItems: "center",
-                }}
+        <Flex variant="layout.wrapper">
+          <Header>
+            <HamburgerMenu />
+          </Header>
+          <SideBar>
+            <Nav />
+          </SideBar>
+          <Container
+            variant="main"
+            sx={{
+              flexGrow: 1,
+              flexDirection: "column",
+              alignItems: "center",
+            }}
+          >
+            <WalletConnector loader={loader}>
+              <LiquityProvider
+                loader={loader}
+                unsupportedNetworkFallback={unsupportedNetworkFallback}
+                unsupportedMainnetFallback={<UnsupportedMainnetFallback />}
               >
-                <Switch>
-                  <Route path="/" exact>
-                    <PageSwitcher />
-                  </Route>
-                  <Route path="/borrow" exact>
-                    <VaultPage />
-                  </Route>
-                  <Route path="/earn" exact>
-                    <StabilityPoolPage />
-                  </Route>
-                  <Route path="/redemption">
-                    <RedemptionPage />
-                  </Route>
-                  <Route path="/risky-vaults">
-                    <RiskyVaultsPage />
-                  </Route>
-                </Switch>
-              </Container>
-            </Flex>
-        </TroveViewProvider>
+                <TransactionProvider>
+                  <FunctionalPanel loader={loader}>
+                    <Switch>
+                      <Route path="/" exact>
+                        <PageSwitcher />
+                      </Route>
+                      <Route path="/borrow" exact>
+                        <VaultPage />
+                      </Route>
+                      <Route path="/earn" exact>
+                        <StabilityPoolPage />
+                      </Route>
+                      <Route path="/redemption">
+                        <RedemptionPage />
+                      </Route>
+                      <Route path="/risky-vaults">
+                        <RiskyVaultsPage />
+                      </Route>
+                    </Switch>
+                  </FunctionalPanel>
+                </TransactionProvider>
+              </LiquityProvider>
+            </WalletConnector>
+          </Container>
+        </Flex>
       </Router>
-      <TransactionMonitor />
-    </LiquityStoreProvider>
+    </>            
   );
 };

--- a/packages/dev-frontend/src/LiquityFrontend.tsx
+++ b/packages/dev-frontend/src/LiquityFrontend.tsx
@@ -29,7 +29,7 @@ const UnsupportedMainnetFallback: React.FC = () => (
       flexDirection: "column",
       alignItems: "center",
       justifyContent: "center",
-      height: "100vh",
+      height: "80vh",
       textAlign: "center"
     }}
   >
@@ -50,7 +50,7 @@ export const LiquityFrontend: React.FC<LiquityFrontendProps> = ({ loader }) => {
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        height: "100vh",
+        height: "80vh",
         textAlign: "center"
       }}
     >

--- a/packages/dev-frontend/src/LiquityFrontend.tsx
+++ b/packages/dev-frontend/src/LiquityFrontend.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { Flex, Container } from "theme-ui";
+import { Flex, Container, Heading, Paragraph } from "theme-ui";
 import { HashRouter as Router, Switch, Route } from "react-router-dom";
 
 import { Nav } from "./components/Nav";
 import { SideBar } from "./components/SideBar";
 import { HamburgerMenu } from "./components/HamburgerMenu";
+import { Icon } from "./components/Icon";
 import { Header } from "./components/Header";
 import { WalletConnector } from "./components/WalletConnector";
 import { TransactionProvider } from "./components/Transaction";
@@ -32,13 +33,13 @@ const UnsupportedMainnetFallback: React.FC = () => (
       textAlign: "center"
     }}
   >
-    
-      This app is for testing purposes only.
-  
+    <Heading sx={{ mb: 3 }}>
+      <Icon name="exclamation-triangle" /> This app is for testing purposes only.
+    </Heading>
 
-
+    <Paragraph sx={{ mb: 3 }}>
       Please change your network to Ropsten.
-  
+    </Paragraph>
   </Flex>
 );
 
@@ -53,11 +54,11 @@ export const LiquityFrontend: React.FC<LiquityFrontendProps> = ({ loader }) => {
         textAlign: "center"
       }}
     >
-      
-        hreshold USD is not yet deployed to{" "}
+      <Heading sx={{ mb: 3 }}>
+        <Icon name="exclamation-triangle" /> Threshold USD is not yet deployed to{" "}
         {chainId === 1 ? "mainnet" : "this network"}.
-
-      Please switch to Ropsten.
+      </Heading>
+      Please switch to Rinkeby.
     </Flex>
   );
 

--- a/packages/dev-frontend/src/components/FunctionalPanel.tsx
+++ b/packages/dev-frontend/src/components/FunctionalPanel.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Wallet } from "@ethersproject/wallet";
+
+import { Decimal, Difference, Trove } from "@liquity/lib-base";
+import { LiquityStoreProvider } from "@liquity/lib-react";
+
+import { useLiquity } from "../hooks/LiquityContext";
+import { TroveViewProvider } from "./Trove/context/TroveViewProvider";
+import { TransactionMonitor } from "./Transaction";
+
+type FunctionalPanelProps = {
+  loader?: React.ReactNode;
+};
+
+export const FunctionalPanel: React.FC<FunctionalPanelProps> = ({ children, loader }) => {
+
+  const { account, provider, liquity } = useLiquity();
+
+  // For console tinkering ;-)
+  Object.assign(window, {
+    account,
+    provider,
+    liquity,
+    Trove,
+    Decimal,
+    Difference,
+    Wallet
+  });
+
+  return (
+    <>
+      <LiquityStoreProvider {...{ loader }} store={liquity.store}>
+        <TroveViewProvider>
+          {children}
+        </TroveViewProvider>
+      </LiquityStoreProvider>
+      <TransactionMonitor />
+    </>            
+  );
+};

--- a/packages/dev-frontend/src/components/UserAccount.tsx
+++ b/packages/dev-frontend/src/components/UserAccount.tsx
@@ -1,22 +1,47 @@
 import React from "react";
+import { useWeb3React } from "@web3-react/core";
 import { Text, Flex, Box, Image } from "theme-ui";
 
-import { useLiquity } from "../hooks/LiquityContext";
 import { shortenAddress } from "../utils/shortenAddress";
+import { injectedConnector } from "../connectors/injectedConnector";
 
 export const UserAccount: React.FC = () => {
-  const { account } = useLiquity();
+  const { activate, deactivate,  active, account } = useWeb3React<unknown>();
 
-  return (
-    <Box>
-      <Flex variant="layout.userAccount">
-        <Image src="./icons/metamask.png" sx={{ height: "16px" }} />
-        <Flex variant="layout.account">
-          <Text as="span" sx={{ fontSize: "0.8rem", fontWeight: "bold" }}>
-            {shortenAddress(account)}
-          </Text>
+  if (active) {
+    return (
+      <Box
+        sx={{ cursor: "pointer" }}
+        onClick={() => {
+          deactivate();
+        }}
+      >
+        <Flex variant="layout.userAccount">
+          <Image src="./icons/metamask.png" sx={{ height: "16px" }} />
+          <Flex variant="layout.account">
+            <Text as="span" sx={{ fontSize: "0.8rem", fontWeight: "bold" }}>
+              {account ?  shortenAddress(account) : 'Connect Wallet'}
+            </Text>
+          </Flex>
         </Flex>
-      </Flex>
-    </Box>
-  );
+      </Box>
+    );
+  } else {
+    return (
+      <Box
+        sx={{ cursor: "pointer" }}
+        onClick={() => {
+          activate(injectedConnector);
+        }}
+      >
+        <Flex variant="layout.userAccount">
+          <Image src="./icons/metamask.png" sx={{ height: "16px" }} />
+          <Flex variant="layout.account">
+            <Text as="span" sx={{ fontSize: "0.8rem", fontWeight: "bold" }}>
+              Connect Wallet
+            </Text>
+          </Flex>
+        </Flex>
+      </Box>
+    )}
 };

--- a/packages/dev-frontend/src/components/WalletConnector.tsx
+++ b/packages/dev-frontend/src/components/WalletConnector.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useReducer } from "react";
 import { useWeb3React } from "@web3-react/core";
 import { AbstractConnector } from "@web3-react/abstract-connector";
-import { Button, Card, Flex, Spinner, Box, Heading, Paragraph } from "theme-ui";
+import { Button, Flex, Spinner, Box, Heading, Paragraph } from "theme-ui";
 
 import { injectedConnector } from "../connectors/injectedConnector";
 import { useAuthorizedConnection } from "../hooks/useAuthorizedConnection";

--- a/packages/dev-frontend/src/theme.ts
+++ b/packages/dev-frontend/src/theme.ts
@@ -9,7 +9,7 @@ const baseColors = {
   red: "#dc2c10",
   lightRed: "#ff755f",
   lightgrey: "#e8eef3",
-  grey: "#959EB1",
+  grey: "#6A7793",
   lightBlue: "#F6F7FA",
 };
 
@@ -513,8 +513,6 @@ const theme: Theme = {
 
     modalOverlay: {
       ...modalOverlay,
-
-      bg: "white",
 
       display: "flex",
       justifyContent: "center",


### PR DESCRIPTION
The app contexts have been refactored in order to wrap the connect wallet within the application, enabling the user to connect and disconnect his wallet by clicking on the header wallet button.

The layout has been implemented following our current Figma design: https://www.figma.com/file/Kuc4Gp7gn1nsAbwhei1Fr0/Threshold-USD-Design-Drafts?node-id=161%3A143

closes #28 

Video:

https://user-images.githubusercontent.com/60587527/170442414-547e328e-6f83-47c1-8c68-d351a5f8588d.mp4
